### PR TITLE
PHP-FPM configs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -123,7 +123,7 @@ RUN { \
     echo '[global]'; \
     echo 'emergency_restart_threshold=3'; \
     echo 'emergency_restart_interval=1m'; \
-    echo 'process_control_timeout=60s'; \
+    echo 'process_control_timeout=5s'; \
 	} > /usr/local/etc/php-fpm.d/zz-extra.conf
 
 # Enable sendmail

--- a/Dockerfile
+++ b/Dockerfile
@@ -124,12 +124,6 @@ RUN { \
     echo 'emergency_restart_threshold=3'; \
     echo 'emergency_restart_interval=1m'; \
     echo 'process_control_timeout=60s'; \
-    echo '[www]'; \
-    echo 'pm.max_children = 75'; \
-    echo 'pm.start_servers = 10'; \
-    echo 'pm.min_spare_servers = 5'; \
-    echo 'pm.max_spare_servers = 20'; \
-    echo 'pm.process_idle_timeout = 10s'; \
 	} > /usr/local/etc/php-fpm.d/zz-extra.conf
 
 # Enable sendmail

--- a/Dockerfile
+++ b/Dockerfile
@@ -118,6 +118,20 @@ RUN { \
     echo 'post_max_size = 256M'; \
 	} > /usr/local/etc/php/conf.d/extra.ini
 
+  # PHP-FPM configs
+RUN { \
+    echo '[global]'; \
+    echo 'emergency_restart_threshold=3'; \
+    echo 'emergency_restart_interval=1m'; \
+    echo 'process_control_timeout=60s'; \
+    echo '[www]'; \
+    echo 'pm.max_children = 75'; \
+    echo 'pm.start_servers = 10'; \
+    echo 'pm.min_spare_servers = 5'; \
+    echo 'pm.max_spare_servers = 20'; \
+    echo 'pm.process_idle_timeout = 10s'; \
+	} > /usr/local/etc/php-fpm.d/zz-extra.conf
+
 # Enable sendmail
 ## RUN \
   #
@@ -152,4 +166,4 @@ EXPOSE 80
 
 ENTRYPOINT ["/usr/local/docker-entrypoint.sh"]
 # Start PHP-FPM and Nginx servers
-CMD php-fpm & nginx -g "daemon off;" -c "/etc/nginx/nginx.conf"
+CMD php-fpm -y "/usr/local/etc/php-fpm.conf" & nginx -g "daemon off;" -c "/etc/nginx/nginx.conf"


### PR DESCRIPTION
- Adds extra PHP-FPM configs that are disabled by default:
```
[global]
emergency_restart_threshold=3
emergency_restart_interval=1m
process_control_timeout=5s
```
If 3 PHP-FPM child processes exit with SIGSEGV or SIGBUS (i.e. crash) within 1 minute then PHP-FPM is supposed to restart automatically, The child processes wait 5s for a reaction on signals from master.
