### PR TITLE
restart php-fpm every 20 minutes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -124,7 +124,7 @@ RUN { \
     echo 'emergency_restart_threshold=3'; \
     echo 'emergency_restart_interval=1m'; \
     echo 'process_control_timeout=5s'; \
-	} > /usr/local/etc/php-fpm.d/zz-extra.conf
+	} > /usr/local/etc/php-fpm.d/zzz-extra.conf
 
 # Enable sendmail
 ## RUN \
@@ -152,12 +152,14 @@ ENV WORDPRESS_DB_NAME=test_db
 # Add wordpress entrypoint
 COPY docker-entrypoint.sh /usr/local/docker-entrypoint.sh
 RUN chmod +x /usr/local/docker-entrypoint.sh
+# Add php-fpm service
+COPY php-fpm.sh /usr/local/php-fpm.sh
+RUN chmod +x /usr/local/php-fpm.sh
 
 VOLUME /var/www/html
-
 # Expose port 80 for Nginx
 EXPOSE 80
 
 ENTRYPOINT ["/usr/local/docker-entrypoint.sh"]
 # Start PHP-FPM and Nginx servers
-CMD php-fpm -y "/usr/local/etc/php-fpm.conf" & nginx -g "daemon off;" -c "/etc/nginx/nginx.conf"
+CMD /usr/local/php-fpm.sh & nginx -g "daemon off;" -c "/etc/nginx/nginx.conf"

--- a/php-fpm.sh
+++ b/php-fpm.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+pidfile="/usr/local/bin/php-fpm-pid"
+# Start the process
+php-fpm -g $pidfile &
+# Wait for 10 seconds
+sleep 10
+# Kill the process
+pid=$(cat $pidfile)
+kill $pid
+# start the loop that restarts php-fpm each 20 minutes
+while true; do
+    # Start the process
+    php-fpm -g $pidfile &
+    # Wait for 20 minutes
+    sleep 1200
+    # Kill the process
+    pid=$(cat $pidfile)
+    kill $pid
+done

--- a/wp-config.php
+++ b/wp-config.php
@@ -116,13 +116,14 @@ define( 'WP_DEBUG', !!getenv_docker('WORDPRESS_DEBUG', '') );
 
 // If we're behind a proxy server and using HTTPS, we need to alert WordPress of that fact
 // see also https://wordpress.org/support/article/administration-over-ssl/#using-a-reverse-proxy
- if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && strpos($_SERVER['HTTP_X_FORWARDED_PROTO'], 'https') !== false) {
-	 $_SERVER['HTTPS'] = 'on';
- } else {
-   define( 'WP_HOME', 'http://' . $_SERVER['HTTP_HOST'] . '/' );
-   define( 'WP_SITEURL', 'http://' . $_SERVER['HTTP_HOST'] . '/' );
- }
-
+if (!empty($_SERVER['HTTP_HOST'])) {
+  if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && strpos($_SERVER['HTTP_X_FORWARDED_PROTO'], 'https') !== false) {
+    $_SERVER['HTTPS'] = 'on';
+  } else {
+    define( 'WP_HOME', 'http://' . $_SERVER['HTTP_HOST'] . '/' );
+    define( 'WP_SITEURL', 'http://' . $_SERVER['HTTP_HOST'] . '/' );
+  }
+}
 
 // (we include this by default because reverse proxying is extremely common in container environments)
 
@@ -145,3 +146,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /** Sets up WordPress vars and included files. */
 require_once ABSPATH . 'wp-settings.php';
+
+if (empty($_SERVER['HTTP_HOST'])) {
+  // request comming from FDM health check
+    echo 'OK';
+    exit(0);
+}


### PR DESCRIPTION
- Restarting php-fpm every 20 minutes
- Reducing response payload for FDM health checks, This also fixes php warnings caused by FDM checks.