### PR TITLE
Fix for WP-CRON issues

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -113,7 +113,7 @@ $table_prefix = getenv_docker('WORDPRESS_TABLE_PREFIX', 'wp_');
 define( 'WP_DEBUG', !!getenv_docker('WORDPRESS_DEBUG', '') );
 /* Add any custom values between this line and the "stop editing" line. */
 
-// request comming from FDM health check, check DB connection
+// Check DB connection
 $mysqli = new mysqli(DB_HOST, DB_USER, DB_PASSWORD, DB_NAME);
 $is_slave = true;
 if ($mysqli->connect_errno) {

--- a/wp-config.php
+++ b/wp-config.php
@@ -123,6 +123,8 @@ if (!empty($_SERVER['HTTP_HOST'])) {
     define( 'WP_SITEURL', 'http://' . $_SERVER['HTTP_HOST'] . '/' );
   }
 } else {
+    //Disable cron on slave nodes
+    define('DISABLE_WP_CRON',true);
     // request comming from FDM health check, check DB connection
     $mysqli = new mysqli(DB_HOST, DB_USER, DB_PASSWORD, DB_NAME);
     if ($mysqli->connect_errno) {
@@ -143,7 +145,6 @@ if ($configExtra = getenv_docker('WORDPRESS_CONFIG_EXTRA', '')) {
 }
 
 define( 'WP_AUTO_UPDATE_CORE', false );
-define('DISABLE_WP_CRON',true);
 define( 'WP_MEMORY_LIMIT', '1024M' );
 
 # define( 'WP_DEBUG', true);


### PR DESCRIPTION
- WP-CRON will be enabled only for the master node, this will fix the issue of plugins that need wp-cron to work and will not cause cron-job conflicts between other slave nodes (wp-cron will remain disabled on slaves).
- Updates WP to v6.3.2