### PR TITLE
Deploy Wordpress v6.4.1

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -8,23 +8,15 @@
     "tag": "6.3.2-fpm"
   },
   {
-    "name": "6.3.2-php8.0",
-    "tag": "6.3.2-php8.0-fpm"
-  },
-  {
     "name": "6.3",
     "tag": "6.3-fpm"
-  },
-  {
-    "name": "6.3-php8.0",
-    "tag": "6.3-php8.0-fpm"
   },
   {
     "name": "6.4",
     "tag": "6.4-fpm"
   },
   {
-    "name": "latest-php8.2",
-    "tag": "php8.2-fpm"
+    "name": "6.4.1",
+    "tag": "6.4.1-fpm"
   }
 ]

--- a/versions.json
+++ b/versions.json
@@ -22,5 +22,9 @@
   {
     "name": "6.4",
     "tag": "6.4-fpm"
+  },
+  {
+    "name": "latest-php8.2",
+    "tag": "php8.2-fpm"
   }
 ]


### PR DESCRIPTION
- Adds v6.4.1
- Removes php v8.0 tags as they are already included in the base versions