### PR TITLE
Redis support + WP core stability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -149,14 +149,8 @@ RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli
     && chmod +x wp-cli.phar \
     && mv wp-cli.phar /usr/local/bin/wp
 
-# Configure SSH server for SFTP and key-based authentication
-#RUN mkdir /var/run/sshd \
-#    && sed -i 's/^#PasswordAuthentication yes/PasswordAuthentication no/' /etc/ssh/sshd_config \
-#    && sed -i 's/#Port 22/Port 2222/' /etc/ssh/sshd_config \
-#    && sed -i 's/#AuthorizedKeysFile/AuthorizedKeysFile/' /etc/ssh/sshd_config \
-#    && sed -i 's/^Subsystem\s\+sftp\s\+\/usr\/lib\/openssh\/sftp-server/Subsystem sftp internal-sftp/' /etc/ssh/sshd_config \
-#    && echo 'Match User sftpuser\nChrootDirectory /var/www/%u\nForceCommand internal-sftp\nX11Forwarding no\nAllowTcpForwarding no' >> /etc/ssh/sshd_config
-
+# Install Redis server package
+RUN apt-get install -y redis-server
 
 #Configure SSH server
 RUN sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config && \
@@ -207,4 +201,4 @@ EXPOSE 2222/tcp
 
 ENTRYPOINT ["/usr/local/docker-entrypoint.sh"]
 # Start PHP-FPM and Nginx servers
-CMD /usr/local/php-fpm.sh & nginx -g "daemon off;" -c "/var/www/html/nginx.conf" & /usr/sbin/sshd -D
+CMD /usr/local/php-fpm.sh & nginx -g "daemon off;" -c "/var/www/html/nginx.conf" & /usr/sbin/sshd -D & redis-server

--- a/wp-config.php
+++ b/wp-config.php
@@ -134,7 +134,11 @@ catch(Exception $e) {
   //Disable WP_AUTO_UPDATE_CORE on slave nodes
   define( 'WP_AUTO_UPDATE_CORE', false );
 }
-
+if ( $is_slave ) {
+  header('HTTP/1.1 500 Internal Server Error');
+  echo 'This node is not active';
+  exit(0);
+} 
 // If we're behind a proxy server and using HTTPS, we need to alert WordPress of that fact
 // see also https://wordpress.org/support/article/administration-over-ssl/#using-a-reverse-proxy
 if ( !empty( $_SERVER['HTTP_HOST'] ) || $_SERVER['REMOTE_ADDR'] === '127.0.0.1' ) {

--- a/wp-config.php
+++ b/wp-config.php
@@ -135,8 +135,8 @@ catch(Exception $e) {
   define( 'WP_AUTO_UPDATE_CORE', false );
 }
 if ( $is_slave ) {
-  header('HTTP/1.1 500 Internal Server Error');
-  echo 'This node is not active';
+  header('HTTP/1.1 503 Service Unavailable');
+  echo 'Standby node. Runs on <a href="https://runonflux.io">Flux</a>';
   exit(0);
 } 
 // If we're behind a proxy server and using HTTPS, we need to alert WordPress of that fact


### PR DESCRIPTION
- Add support for Redis. This reduces load on DB and improves WP performance by enabling object caching. Also can reduce load on Syncthing by enabling caches to be stored in memory.
- Disable wp-core for all slave nodes. By disabling wp-core we ensure that no action or file changes are being made on the slave nodes. This could fixe core file damages caused by sync conflicts.