### PR TITLE
Update docker-entrypoint.sh - Load ENVs from file

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,17 @@
 #!/usr/bin/env bash
+# Load the .env file
+if [ -f "${DOTENV_PATH:-/var/www/html/.env}" ]; then
+    # Export environment variables from the .env file
+    while IFS='=' read -r key value; do
+        # Skip comments and empty lines
+        if [[ ! "$key" =~ ^# && -n "$key" ]]; then
+            export "$key=$value"
+        fi
+    done < "${DOTENV_PATH:-/var/www/html/.env}"
+else
+    echo ".env file not found"
+fi
+
 set -Eeuo pipefail
 
 sourceTarArgs=(


### PR DESCRIPTION
This commit allows the end user to upload a .env file from the "Interactive Terminal" tab under the Volume Browser section. 

The user would then use the upload button to upload their .env file.

Finally, the user would go to global component control and restart the app to have it pickup the file.

WORDPRESS_DB_HOST=operator:3307
WORDPRESS_DB_USER=root
WORDPRESS_DB_PASSWORD=secret
WORDPRESS_DB_NAME=test_db
#PUBLIC_KEY=